### PR TITLE
2.1.0 layout fix for XP and radiation

### DIFF
--- a/dist/css/alien-crt-ui.css
+++ b/dist/css/alien-crt-ui.css
@@ -767,6 +767,8 @@ combobox:focus {
 .alienrpg .crt_Item1 .xp_faded {
 	padding-top: 6px;
 	color: var(--aliendarkergreen);
+	display: inline-flex;
+	width: 160px;
 }
 
 .alienrpg .crt_Item1 h2 {
@@ -833,6 +835,7 @@ combobox:focus {
     padding-bottom: 38px !important;
     align-items: center !important;
     margin-top: 5px;
+	flex-wrap: nowrap;
 }
 
 .alienrpg .dots.radiation.rad_glow {

--- a/dist/css/alien-crt-ui.css
+++ b/dist/css/alien-crt-ui.css
@@ -835,7 +835,7 @@ combobox:focus {
     padding-bottom: 38px !important;
     align-items: center !important;
     margin-top: 5px;
-	flex-wrap: nowrap;
+    flex-wrap: nowrap;
 }
 
 .alienrpg .dots.radiation.rad_glow {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/203647/162561095-9a83c065-15b5-4c7e-a197-203a72b428c3.png)

I took the CSS pretty much straight from the Alien RPG 2.1.0 commit that caused the issue here: https://github.com/pwatson100/alienrpg/commit/bd8db2b991050e47aef99bcc865ebec172caf262

This addresses some of the layout problems mentioned in #12

But I did not touch any of the tabs.