### PR TITLE
Add default chat message style to emotes

### DIFF
--- a/dist/css/alien-crt-ui.css
+++ b/dist/css/alien-crt-ui.css
@@ -317,7 +317,8 @@ combobox:focus {
 	color: #00000000;
 }
 
-.chat-message {
+.chat-message,
+.chat-message.emote {
 	font-family: var(--alienchatfont);
 	font-size: 110%;
 	font-weight: bold;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/203647/163524409-ea173551-df98-4371-812f-19bc7555cfec.png)

I'm just applying the default styling to the emote chats for now. I had opened #14 in case you wanted to do something cooler. #14 also shows what it looked like before.